### PR TITLE
Date fixes for Forecast and QuickCaptureModal

### DIFF
--- a/src/components/QuickCaptureModal.ts
+++ b/src/components/QuickCaptureModal.ts
@@ -553,9 +553,9 @@ export class QuickCaptureModal extends Modal {
 	}
 
 	parseDate(dateString: string): Date {
-    const [year, month, day] = dateString.split('-').map(Number);
-    return new Date(year, month - 1, day); // month is 0-indexed in JavaScript Date
-}
+	    const [year, month, day] = dateString.split('-').map(Number);
+	    return new Date(year, month - 1, day); // month is 0-indexed in JavaScript Date
+	}
 
 	onClose() {
 		const { contentEl } = this;

--- a/src/components/QuickCaptureModal.ts
+++ b/src/components/QuickCaptureModal.ts
@@ -553,8 +553,9 @@ export class QuickCaptureModal extends Modal {
 	}
 
 	parseDate(dateString: string): Date {
-		return new Date(dateString);
-	}
+    const [year, month, day] = dateString.split('-').map(Number);
+    return new Date(year, month - 1, day); // month is 0-indexed in JavaScript Date
+}
 
 	onClose() {
 		const { contentEl } = this;

--- a/src/components/task-view/forecast.ts
+++ b/src/components/task-view/forecast.ts
@@ -619,11 +619,14 @@ export class ForecastComponent extends Component {
 		const sortedDates = Array.from(dateMap.keys()).sort();
 
 		sortedDates.forEach((dateKey) => {
-			const date = new Date(dateKey);
-			const tasks = dateMap.get(dateKey)!;
-
-			const today = new Date(this.currentDate);
-			today.setHours(0, 0, 0, 0);
+    // Parse the date components from the string "YYYY-MM-DD"
+    const [year, month, day] = dateKey.split('-').map(Number);
+    // Create date with local components (month is 0-indexed in JavaScript)
+    const date = new Date(year, month - 1, day);
+    const tasks = dateMap.get(dateKey)!;
+    
+    const today = new Date(this.currentDate);
+    today.setHours(0, 0, 0, 0);
 
 			const dayDiff = Math.round(
 				(date.getTime() - today.getTime()) / (1000 * 3600 * 24)
@@ -914,12 +917,11 @@ export class ForecastComponent extends Component {
 		});
 		const sortedDates = Array.from(dateMap.keys()).sort();
 		sortedDates.forEach((dateKey) => {
-			const date = new Date(dateKey);
-			const tasks = dateMap.get(dateKey)!;
-
-			const selectedDate = new Date(this.selectedDate);
-			selectedDate.setHours(0, 0, 0, 0);
-
+    // Parse the date components from the string "YYYY-MM-DD"
+    const [year, month, day] = dateKey.split('-').map(Number);
+    // Create date with local components (month is 0-indexed in JavaScript)
+    const date = new Date(year, month - 1, day);
+    const tasks = dateMap.get(dateKey)!;
 			const dayDiff = Math.round(
 				(date.getTime() - selectedDate.getTime()) / (1000 * 3600 * 24)
 			);

--- a/src/components/task-view/forecast.ts
+++ b/src/components/task-view/forecast.ts
@@ -922,6 +922,10 @@ export class ForecastComponent extends Component {
     // Create date with local components (month is 0-indexed in JavaScript)
     const date = new Date(year, month - 1, day);
     const tasks = dateMap.get(dateKey)!;
+
+			const selectedDate = new Date(this.selectedDate);
+			selectedDate.setHours(0, 0, 0, 0);
+			
 			const dayDiff = Math.round(
 				(date.getTime() - selectedDate.getTime()) / (1000 * 3600 * 24)
 			);

--- a/src/components/task-view/forecast.ts
+++ b/src/components/task-view/forecast.ts
@@ -619,14 +619,14 @@ export class ForecastComponent extends Component {
 		const sortedDates = Array.from(dateMap.keys()).sort();
 
 		sortedDates.forEach((dateKey) => {
-    // Parse the date components from the string "YYYY-MM-DD"
-    const [year, month, day] = dateKey.split('-').map(Number);
-    // Create date with local components (month is 0-indexed in JavaScript)
-    const date = new Date(year, month - 1, day);
-    const tasks = dateMap.get(dateKey)!;
-    
-    const today = new Date(this.currentDate);
-    today.setHours(0, 0, 0, 0);
+		    // Parse the date components from the string "YYYY-MM-DD"
+		    const [year, month, day] = dateKey.split('-').map(Number);
+		    // Create date with local components (month is 0-indexed in JavaScript)
+		    const date = new Date(year, month - 1, day);
+		    const tasks = dateMap.get(dateKey)!;
+		    
+		    const today = new Date(this.currentDate);
+		    today.setHours(0, 0, 0, 0);
 
 			const dayDiff = Math.round(
 				(date.getTime() - today.getTime()) / (1000 * 3600 * 24)
@@ -917,11 +917,11 @@ export class ForecastComponent extends Component {
 		});
 		const sortedDates = Array.from(dateMap.keys()).sort();
 		sortedDates.forEach((dateKey) => {
-    // Parse the date components from the string "YYYY-MM-DD"
-    const [year, month, day] = dateKey.split('-').map(Number);
-    // Create date with local components (month is 0-indexed in JavaScript)
-    const date = new Date(year, month - 1, day);
-    const tasks = dateMap.get(dateKey)!;
+		    // Parse the date components from the string "YYYY-MM-DD"
+		    const [year, month, day] = dateKey.split('-').map(Number);
+		    // Create date with local components (month is 0-indexed in JavaScript)
+		    const date = new Date(year, month - 1, day);
+		    const tasks = dateMap.get(dateKey)!;
 
 			const selectedDate = new Date(this.selectedDate);
 			selectedDate.setHours(0, 0, 0, 0);


### PR DESCRIPTION
This PR addresses date related issues in both Forecast and the QuickCaptureModal:

Forecast View: Previously, tasks in the right column were displaying as one day off from their actual due date. This has been corrected.

QuickCaptureModal: The date pickers were entering dates one day earlier than the selected value. This behavior has now been fixed.

These fixes work for me on windows.