### PR TITLE
fix(mcp): ensure protocol compliance and consistent tag formatting

### DIFF
--- a/src/mcp/bridge/TaskManagerBridge.ts
+++ b/src/mcp/bridge/TaskManagerBridge.ts
@@ -556,15 +556,10 @@ export class TaskManagerBridge {
 		const metadata: string[] = [];
 		const useDataviewFormat = this.plugin.settings.preferMetadataFormat === "dataview";
 
-		// 1. Tags (handle both formats)
+		// 1. Tags (always use hashtag format for both dataview and tasks)
 		if (args.tags?.length) {
-			if (useDataviewFormat) {
-				// In dataview format, tags are stored as a field
-				metadata.push(`[tags:: ${args.tags.join(", ")}]`);
-			} else {
-				// In tasks format, use hashtags
-				metadata.push(...args.tags.map(tag => `#${tag}`));
-			}
+			// Always use hashtags format regardless of metadata format preference
+			metadata.push(...args.tags.map(tag => `#${tag}`));
 		}
 
 		// 2. Project


### PR DESCRIPTION
- Return proper 404 status for invalid sessions and root endpoint
- Add protocol version default (2025-03-26) when header missing
- Validate Accept headers on POST/GET requests per spec
- Return 202 Accepted for notifications/responses, 200 for requests
- Always use hashtag format (#tag) for tags in both dataview and tasks modes

These changes ensure full compliance with MCP Streamable HTTP transport specification and provide consistent tag handling across metadata formats.