### PR TITLE
fix: use constant-time comparison for auth token (CWE-208)

### DIFF
--- a/src/mcp/auth/AuthMiddleware.ts
+++ b/src/mcp/auth/AuthMiddleware.ts
@@ -3,6 +3,17 @@
  */
 
 import { IncomingMessage, ServerResponse } from "http";
+import { timingSafeEqual, createHash } from "crypto";
+
+function safeEqual(a: string, b: string): boolean {
+	try {
+		const hashA = createHash("sha256").update(a).digest();
+		const hashB = createHash("sha256").update(b).digest();
+		return timingSafeEqual(hashA, hashB);
+	} catch {
+		return false;
+	}
+}
 
 export class AuthMiddleware {
 	constructor(private authToken: string) {}
@@ -19,7 +30,7 @@ export class AuthMiddleware {
 		if (!parsed) {
 			return false;
 		}
-		return parsed.token === this.authToken;
+		return safeEqual(parsed.token, this.authToken);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Fixes #575 — replaces timing-vulnerable `===` comparison with constant-time `timingSafeEqual` via SHA-256 digest.

## Changes
- Add `safeEqual()` helper using `crypto.createHash` + `crypto.timingSafeEqual`
- Replace direct `===` in `validateRequest()` with constant-time comparison
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`crypto`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*